### PR TITLE
Fixed creategpo and -listsite bugs

### DIFF
--- a/GPOwned.py
+++ b/GPOwned.py
@@ -919,7 +919,7 @@ displayName={display_name}
             self.smbconn.createDirectory("SYSVOL", f"{domain}/Policies/{{{gpo_guid}}}")
             self.smbconn.createDirectory("SYSVOL", f"{domain}/Policies/{{{gpo_guid}}}/Machine")
             self.smbconn.createDirectory("SYSVOL", f"{domain}/Policies/{{{gpo_guid}}}/User")
-            self.smbconn.putFile("SYSVOL", f"inlanefreight.local/Policies/{{{gpo_guid}}}/GPT.INI", fh.read)
+            self.smbconn.putFile("SYSVOL", f"{domain}/Policies/{{{gpo_guid}}}/GPT.INI", fh.read)
 
             fh.close()
             os.remove("./GPT.INI")
@@ -930,7 +930,7 @@ displayName={display_name}
                 fh = open("./GPO.cmt", "w+b")
                 fh.write(comment.encode('utf-8'))
                 fh.seek(0)
-                self.smbconn.putFile("SYSVOL", f"inlanefreight.local/Policies/{{{gpo_guid}}}/GPO.cmt", fh.read)
+                self.smbconn.putFile("SYSVOL", f"{domain}/Policies/{{{gpo_guid}}}/GPO.cmt", fh.read)
 
                 fh.close()
                 os.remove("./GPO.cmt")
@@ -1906,7 +1906,12 @@ def main():
             name = options.name
         records = helper.ldapGPOFromSiteInfo(name)
         for x in records:
-            print("\n[+] Name: %s\n\t[-] distinguishedName: %s\n\t[-] gPLink: %s\n\t[-] objectGUID: %s\n\t[-] objectcategory: %s" % (x["Name"], x["distinguishedName"], x["gPLink"], x["objectGUID"], x['objectcategory']))
+
+            objectGUID = x["objectGUID"]
+            if isinstance(x["objectGUID"].raw_values[0], bytes):
+                objectGUID = uuid.UUID(bytes_le=x["objectGUID"].raw_values[0])
+
+            print("\n[+] Name: %s\n\t[-] distinguishedName: %s\n\t[-] gPLink: %s\n\t[-] objectGUID: %s\n\t[-] objectcategory: %s" % (x["Name"], x["distinguishedName"], x["gPLink"], objectGUID, x['objectcategory']))
 
     # -listou
     if options.listou is True:

--- a/README.md
+++ b/README.md
@@ -463,7 +463,3 @@ proxychains4 -q python3 GPOwned.py -u gabriel -aesKey 0A7FF58D7CB12557E46351FCAB
 ## Ldaps
 
 -use-ldaps have some bugs with ssl error EOF, no ideia if is a problem with the domain of in the code
-
-## Kerberos connection does not return the correct gpLink attribute when using the flag -listgpo
-
-For some reason kerberos return a strange output when asking for the gpLink


### PR DESCRIPTION
Hi again, I fixed some problems with 2 params from the tittle.

1 - listsite using kerberos gave a strange output for the objectguid, what I did was simple, identify if the istance of the ldap entry is an object and if so get the real object GUID value, if the value is not bytes then continue with the script the same way as it was before.

2 - creategpo had some leftovers from the "inlanefreight.local" which was the domain I used from the htb academy modules, removed those leftovers to retrieve the domain passed in the -domain parameter